### PR TITLE
Directly adding new asset extension

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -3,6 +3,6 @@ const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname);
 
-config.resolver.assetExts = [...config.resolver.assetExts, "riv"];
+config.resolver.assetExts.push("riv");
 
 module.exports = config;


### PR DESCRIPTION
This is the preferred way to resolve new extensions: https://docs.expo.dev/guides/customizing-metro/#adding-more-file-extensions-to-assetexts